### PR TITLE
VS-6831 / VS-6832

### DIFF
--- a/vsd-app/ClientApp/src/app/home/home.component.html
+++ b/vsd-app/ClientApp/src/app/home/home.component.html
@@ -48,6 +48,7 @@
                 <br>
                 <p>
                   Changes to the <i>Crime Victim Assistance Act</i> came into effect on January 1, 2024 and expanded the definition of Immediate Family Member. If you are applying in relation to an offence that happened before January 1, 2024, the definition of Immediate Family Member that was in effect at that time will apply.
+                  <app-tool-tip [trigger]="changestotheCrimeVictim"></app-tool-tip>
                 </p>
               </div>
 
@@ -129,4 +130,6 @@
     </div>
   </div>
 </div>
-
+<ng-template #changestotheCrimeVictim>
+  For offences that occurred before January 1, 2024, an Immediate Family Member is defined as a person who, at the time of the eligible offence that resulted in the death or injury of a victim, was a spouse, child, sibling, step sibling,half sibling, parent of the victim or, <strong>if financially dependent on the victim, a grandparent or grandchild of the victim.</strong>
+</ng-template>

--- a/vsd-app/ClientApp/src/app/home/home.component.html
+++ b/vsd-app/ClientApp/src/app/home/home.component.html
@@ -54,7 +54,12 @@
 
               <div *ngIf="selectedApplicationType === 100000000" class="attention">
                 <p>
-                  This application package is designed for a <strong>Witness</strong> of an injured or deceased victim of violent crime. Under the <em>Crime Victim Assistance Act</em>, a witness is a person who is not related to the victim but has a strong emotional attachment to the victim and witnesses in close proximity an eligible offence that causes a life-threatening injury or death to the victim or witnesses the immediate aftermath of an eligible offence that caused the death of the victim.
+                  This application package is designed for a <strong>Witness</strong> of an injured or deceased victim of violent crime. Under the <em>Crime Victim Assistance Act</em>, a witness is a person who witnesses in close proximity a prescribed, or the immediate aftermath of a prescribed offence, that causes a life-threatening injury to, or the death of, the victim.
+                </p>
+                <br>
+                <p>
+                  Changes to the <i>Crime Victim Assistance Act</i> came into effect on January 1, 2024 and expanded the definition of Witness. If you are applying in relation to an offence that happened before January 1, 2024, the definition of Wtness that was in effect at that time will apply.
+                  <app-tool-tip [trigger]="witnessTooltip"></app-tool-tip>
                 </p>
               </div>
 
@@ -132,4 +137,7 @@
 </div>
 <ng-template #changestotheCrimeVictim>
   For offences that occurred before January 1, 2024, an Immediate Family Member is defined as a person who, at the time of the eligible offence that resulted in the death or injury of a victim, was a spouse, child, sibling, step sibling,half sibling, parent of the victim or, <strong>if financially dependent on the victim, a grandparent or grandchild of the victim.</strong>
+</ng-template>
+<ng-template #witnessTooltip>
+  For offences that occurred before January 1, 2024, a Witness is defined as a person who is not related to the victim but <strong>has a strong emotional attachment to the victim</strong> and witnesses in close proximity an eligible offence that causes a life-threatening injury or death to the victim <strong>or</strong> witnesses the immediate aftermath of an eligible offence that caused the death of the victim.
 </ng-template>

--- a/vsd-app/ClientApp/src/app/shared/expense-information/expense-information.component.html
+++ b/vsd-app/ClientApp/src/app/shared/expense-information/expense-information.component.html
@@ -77,7 +77,7 @@
         <app-field>
           <label>
             <input type="checkbox" [value]="true" name="haveCrimeSceneCleaningExpenses" formControlName="haveCrimeSceneCleaningExpenses" (change)="changeGroupValidity($event)">
-            Crime scene cleaning <app-tool-tip [trigger]="benefitsCrimeScene"></app-tool-tip>
+            Crime scene cleaning expenses <app-tool-tip [trigger]="benefitsCrimeScene"></app-tool-tip>
           </label>
         </app-field>
         <app-field>
@@ -120,8 +120,95 @@
         <app-field>
           <label>
             <input type="checkbox" [value]="true" name="haveCrimeSceneCleaningExpenses" formControlName="haveCrimeSceneCleaningExpenses" (change)="changeGroupValidity($event)">
-            Crime scene cleaning <app-tool-tip [trigger]="expensesFamilyCrimeSceneCleaning"></app-tool-tip>
+            Crime scene cleaning expenses<app-tool-tip [trigger]="expensesFamilyCrimeSceneCleaning"></app-tool-tip>
           </label>
+        </app-field>
+      </ng-container>
+
+      <ng-container *ngIf="formType === ApplicationType.IFM_Application">
+        <app-field>
+          <label>
+            <input type="checkbox" [value]="true" name="haveVocationalServicesExpenses" formControlName="haveVocationalServicesExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
+            Vocational services or training <app-tool-tip [trigger]="expensesVocational"></app-tool-tip>
+          </label>
+        </app-field>
+        <app-field>
+          <label>
+            <input type="checkbox" [value]="true" name="haveIncomeSupportExpenses" formControlName="haveIncomeSupportExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
+            Income support <app-tool-tip [trigger]="expensesIncomeSupport"></app-tool-tip>
+          </label>
+        </app-field>
+        <app-field>
+          <label>
+            <input type="checkbox" [value]="true" name="haveChildcareExpenses" formControlName="haveChildcareExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
+            Childcare <app-tool-tip [trigger]="expensesChildCare"></app-tool-tip>
+          </label>
+        </app-field>
+        <app-field>
+          <label>
+            <input type="checkbox" [value]="true" name="haveLegalProceedingExpenses" formControlName="haveLegalProceedingExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
+            Transportation to attend legal proceedings <app-tool-tip [trigger]="expensesLegalTransportation"></app-tool-tip>
+          </label>
+        </app-field>
+        <app-field>
+          <label>
+            <input type="checkbox" [value]="true" name="haveFuneralExpenses" formControlName="haveFuneralExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
+            Funeral expenses <app-tool-tip [trigger]="expensesFuneral"></app-tool-tip>
+          </label>
+        </app-field>
+        <app-field>
+          <label>
+            <input type="checkbox" [value]="true" name="haveBereavementLeaveExpenses" formControlName="haveBereavementLeaveExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
+            Bereavement leave <app-tool-tip [trigger]="expensesBereavementLeave"></app-tool-tip>
+          </label>
+        </app-field>
+        <app-field>
+          <label>
+            <input type="checkbox" [value]="true" name="haveLostOfParentalGuidanceExpenses" formControlName="haveLostOfParentalGuidanceExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
+            Loss of parental guidance <app-tool-tip [trigger]="expensesParentalLoss"></app-tool-tip>
+          </label>
+        </app-field>
+        <app-field>
+          <label>
+            <input type="checkbox" [value]="true" name="haveHomeMakerExpenses" formControlName="haveHomeMakerExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
+            Homemaker services <app-tool-tip [trigger]="expensesHomemakerServices"></app-tool-tip>
+          </label>
+        </app-field>
+
+        <app-field label="Please provide details of your requests. (Maximum 750 characters)" errorMessage="Please provide details of your requests.">
+          <textarea class="form-control bigger" formControlName="additionalBenefitsDetails" maxlength="750"></textarea>
+        </app-field>
+
+        <app-field [valid]="isFieldValid('minimumAdditionalBenefitsSelected')" errorMessage="Please select at least one option">
+          <input type="hidden" name="minimumAdditionalBenefitsSelected" formControlName="minimumAdditionalBenefitsSelected">
+        </app-field>
+      </ng-container>
+
+      <ng-container *ngIf="formType === ApplicationType.Witness_Application">
+        <app-field>
+          <label>
+            <input type="checkbox" [value]="true" name="haveCrimeSceneCleaningExpenses" formControlName="haveCrimeSceneCleaningExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
+            Crime scene cleaning expenses<app-tool-tip [trigger]="expensesWitnessCrimeSceneCleaning"></app-tool-tip>
+          </label>
+        </app-field>
+        <app-field>
+          <label>
+            <input type="checkbox" [value]="true" name="haveOtherExpenses" formControlName="haveOtherExpenses" (change)="changeAdditionalBenefitGroupValidity($event); haveOtherExpensesChange($event.target.checked)">
+            Other
+          </label>
+          <section *ngIf="form.get('haveOtherExpenses').value === true" class="pushed">
+            <app-field label="Please specify">
+              <input class="form-control standard" type="text" formControlName="otherSpecificExpenses">
+            </app-field>
+          </section>
+        </app-field>
+
+        <app-field label="Please provide details of your requests. (Maximum 750 characters)" errorMessage="Please provide details of your requests.">
+          <textarea class="form-control bigger" formControlName="additionalBenefitsDetails" maxlength="750"></textarea>
+        </app-field>
+
+        <app-field [valid]="isFieldValid('minimumAdditionalBenefitsSelected')" errorMessage="Please select at least one option">
+          <input type="hidden" name="minimumAdditionalBenefitsSelected" formControlName="minimumAdditionalBenefitsSelected">
         </app-field>
       </ng-container>
 
@@ -191,80 +278,7 @@
 
   <!-- IFM Additional Benefits -->
   <ng-container *ngIf="formType === ApplicationType.IFM_Application">
-    <section *ngIf="form.parent.get('crimeInformation.victimDeceasedFromCrime').value == CRMBoolean.True">
-      <h2 class="blue-header">Additional Benefits</h2>
-      <p>If the victim is deceased as a result of the crime, please indicate which additional expenses or benefits you wish to claim (at least one is required):</p>
-      <div class="radio-list">
-        <app-field>
-          <label>
-            <input type="checkbox" [value]="true" name="haveVocationalServicesExpenses" formControlName="haveVocationalServicesExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
-            Vocational services or training <app-tool-tip [trigger]="expensesVocational"></app-tool-tip>
-          </label>
-        </app-field>
-        <app-field>
-          <label>
-            <input type="checkbox" [value]="true" name="haveIncomeSupportExpenses" formControlName="haveIncomeSupportExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
-            Income support <app-tool-tip [trigger]="expensesIncomeSupport"></app-tool-tip>
-          </label>
-        </app-field>
-        <app-field>
-          <label>
-            <input type="checkbox" [value]="true" name="haveChildcareExpenses" formControlName="haveChildcareExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
-            Childcare <app-tool-tip [trigger]="expensesChildCare"></app-tool-tip>
-          </label>
-        </app-field>
-        <app-field>
-          <label>
-            <input type="checkbox" [value]="true" name="haveLegalProceedingExpenses" formControlName="haveLegalProceedingExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
-            Transportation to attend legal proceedings <app-tool-tip [trigger]="expensesLegalTransportation"></app-tool-tip>
-          </label>
-        </app-field>
-        <app-field>
-          <label>
-            <input type="checkbox" [value]="true" name="haveFuneralExpenses" formControlName="haveFuneralExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
-            Funeral expenses <app-tool-tip [trigger]="expensesFuneral"></app-tool-tip>
-          </label>
-        </app-field>
-        <app-field>
-          <label>
-            <input type="checkbox" [value]="true" name="haveBereavementLeaveExpenses" formControlName="haveBereavementLeaveExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
-            Bereavement leave <app-tool-tip [trigger]="expensesBereavementLeave"></app-tool-tip>
-          </label>
-        </app-field>
-        <app-field>
-          <label>
-            <input type="checkbox" [value]="true" name="haveLostOfParentalGuidanceExpenses" formControlName="haveLostOfParentalGuidanceExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
-            Loss of parental guidance <app-tool-tip [trigger]="expensesParentalLoss"></app-tool-tip>
-          </label>
-        </app-field>
-        <app-field>
-          <label>
-            <input type="checkbox" [value]="true" name="haveHomeMakerExpenses" formControlName="haveHomeMakerExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
-            Homemaker services <app-tool-tip [trigger]="expensesHomemakerServices"></app-tool-tip>
-          </label>
-        </app-field>
-        <app-field>
-          <label>
-            <input type="checkbox" [value]="true" name="haveOtherExpenses" formControlName="haveOtherExpenses" (change)="changeAdditionalBenefitGroupValidity($event); haveOtherExpensesChange($event.target.checked)">
-            Other
-          </label>
-          <section *ngIf="form.get('haveOtherExpenses').value === true" class="pushed">
-            <app-field label="Please specify">
-              <input class="form-control standard" type="text" formControlName="otherSpecificExpenses">
-            </app-field>
-          </section>
-        </app-field>
-
-        <app-field label="Please provide details of your requests. (Maximum 750 characters)" errorMessage="Please provide details of your requests.">
-          <textarea class="form-control bigger" formControlName="additionalBenefitsDetails" maxlength="750"></textarea>
-        </app-field>
-
-        <app-field [valid]="isFieldValid('minimumAdditionalBenefitsSelected')" errorMessage="Please select at least one option">
-          <input type="hidden" name="minimumAdditionalBenefitsSelected" formControlName="minimumAdditionalBenefitsSelected">
-        </app-field>
-      </div>
-
-
+    <section>
       <p>The following section provides information regarding employment information. This information is necessary if you are requesting benefits for lost employment income.</p>
       <h2 class="blue-header">Income Loss Information</h2>
 
@@ -443,42 +457,6 @@
       </section>
     </section>
   </ng-container>
-
-  <!-- Witness Additional Benefits -->
-  <ng-container *ngIf="formType === ApplicationType.Witness_Application">
-    <section *ngIf="form.parent.get('crimeInformation.victimDeceasedFromCrime').value == CRMBoolean.True">
-      <h2 class="blue-header">Additional Benefits</h2>
-      <p>If the victim is deceased as a result of the crime, please indicate which additional expenses or benefits you wish to claim (at least one is required):</p>
-      <div class="radio-list">
-        <app-field>
-          <label>
-            <input type="checkbox" [value]="true" name="haveCrimeSceneCleaningExpenses" formControlName="haveCrimeSceneCleaningExpenses" (change)="changeAdditionalBenefitGroupValidity($event)">
-            Crime scene cleaning <app-tool-tip [trigger]="expensesWitnessCrimeSceneCleaning"></app-tool-tip>
-          </label>
-        </app-field>
-        <app-field>
-          <label>
-            <input type="checkbox" [value]="true" name="haveOtherExpenses" formControlName="haveOtherExpenses" (change)="changeAdditionalBenefitGroupValidity($event); haveOtherExpensesChange($event.target.checked)">
-            Other
-          </label>
-          <section *ngIf="form.get('haveOtherExpenses').value === true" class="pushed">
-            <app-field label="Please specify">
-              <input class="form-control standard" type="text" formControlName="otherSpecificExpenses">
-            </app-field>
-          </section>
-        </app-field>
-
-        <app-field label="Please provide details of your requests. (Maximum 750 characters)" errorMessage="Please provide details of your requests.">
-          <textarea class="form-control bigger" formControlName="additionalBenefitsDetails" maxlength="750"></textarea>
-        </app-field>
-
-        <app-field [valid]="isFieldValid('minimumAdditionalBenefitsSelected')" errorMessage="Please select at least one option">
-          <input type="hidden" name="minimumAdditionalBenefitsSelected" formControlName="minimumAdditionalBenefitsSelected">
-        </app-field>
-      </div>
-    </section>
-  </ng-container>
-
 </div>
 
 <!-- Tool tips -->

--- a/vsd-app/ClientApp/src/app/shared/introduction/introduction.component.html
+++ b/vsd-app/ClientApp/src/app/shared/introduction/introduction.component.html
@@ -23,8 +23,12 @@
     <p>If this definition does not apply to you, please see the application forms for <a routerLink="/witness-application">Witnesses</a> or <a routerLink="/victim-application">Victims</a>.</p>
   </div>
   <div *ngIf="formType === ApplicationType.Witness_Application">
-    <p>This application form is designed for a <strong>Witness</strong> of an injured or deceased victim of violent crime. Under the <em>Crime Victim Assistance Act</em>, a witness is a person who is not related to the victim but has a strong emotional attachment to the victim and witnesses in close proximity an eligible offence that causes a life-threatening injury or death to the victim or witnesses the immediate aftermath of an eligible offence that caused the death of the victim.</p>
+    <p>This application package is designed for a <strong>Witness</strong> of an injured or deceased victim of violent crime. Under the <em>Crime Victim Assistance Act</em>, a witness is a person who witnesses in close proximity a prescribed, or the immediate aftermath of a prescribed offence, that causes a life-threatening injury to, or the death of, the victim.</p>
     <p>If this definition does not apply to you, please see the application forms for <a routerLink="/ifm-application">Immediate Family Members</a> or <a routerLink="/victim-application">Victims</a>.</p>
+    <p>
+      Changes to the <i>Crime Victim Assistance Act</i> came into effect on January 1, 2024 and expanded the definition of Witness. If you are applying in relation to an offence that happened before January 1, 2024, the definition of Wtness that was in effect at that time will apply.
+      <app-tool-tip [trigger]="witnessTooltip"></app-tool-tip>
+    </p>
   </div>
 
   <div class="attention">
@@ -130,4 +134,7 @@
 </div>
 <ng-template #changestotheCrimeVictim>
   For offences that occurred before January 1, 2024, an Immediate Family Member is defined as a person who, at the time of the eligible offence that resulted in the death or injury of a victim, was a spouse, child, sibling, step sibling,half sibling, parent of the victim or, <strong>if financially dependent on the victim, a grandparent or grandchild of the victim.</strong>
+</ng-template>
+<ng-template #witnessTooltip>
+  For offences that occurred before January 1, 2024, a Witness is defined as a person who is not related to the victim but <strong>has a strong emotional attachment to the victim</strong> and witnesses in close proximity an eligible offence that causes a life-threatening injury or death to the victim <strong>or</strong> witnesses the immediate aftermath of an eligible offence that caused the death of the victim.
 </ng-template>

--- a/vsd-app/ClientApp/src/app/shared/introduction/introduction.component.html
+++ b/vsd-app/ClientApp/src/app/shared/introduction/introduction.component.html
@@ -129,5 +129,5 @@
   </section>
 </div>
 <ng-template #changestotheCrimeVictim>
-  <p>Changes to the <i>Crime Victim Assistance Act</i> came into effect on January 1, 2024. If you are applying in relation to an offence that happened before January 1, 2024, the eligibility criteria for this benefit that were in effect at that time will apply.</p>
+  For offences that occurred before January 1, 2024, an Immediate Family Member is defined as a person who, at the time of the eligible offence that resulted in the death or injury of a victim, was a spouse, child, sibling, step sibling,half sibling, parent of the victim or, <strong>if financially dependent on the victim, a grandparent or grandchild of the victim.</strong>
 </ng-template>

--- a/vsd-app/ClientApp/src/app/shared/victim-information/victim-information.component.html
+++ b/vsd-app/ClientApp/src/app/shared/victim-information/victim-information.component.html
@@ -2,13 +2,13 @@
     <div class="page-header">
         <h1>Victim Information</h1>
     </div>
-    <h2 class="blue-header">Victim Information</h2>
+    <h2 class="blue-header">Victim Information, if known</h2>
 
     <h3>Victim Name</h3>
 
     <div class="row">
         <div class="col-4">
-            <app-field label="First Name" [required]="true" [valid]="isFieldValid('firstName')" errorMessage="Please enter your first name">
+            <app-field label="First Name" [required]="false" [valid]="isFieldValid('firstName')">
                 <input class="form-control" type="text" formControlName="firstName" maxlength="100">
             </app-field>
         </div>
@@ -18,7 +18,7 @@
             </app-field>
         </div>
         <div class="col-4">
-            <app-field label="Last Name" [required]="true" [valid]="isFieldValid('lastName')" errorMessage="Please enter your last name">
+            <app-field label="Last Name" [required]="false" [valid]="isFieldValid('lastName')">
                 <input class="form-control" type="text" formControlName="lastName" maxlength="100">
             </app-field>
         </div>
@@ -82,7 +82,7 @@
             </app-field>
         </div>
         <div class="col-md-6">
-            <app-field label="Marital Status" [required]="true" [valid]="isFieldValid('maritalStatus')" errorMessage="Please select your marital status">
+            <app-field label="Marital Status" [required]="false" [valid]="isFieldValid('maritalStatus')">
                 <select class="form-control" formControlName="maritalStatus">
                     <option value="0">Select...</option>
                     <option value="100000000">Married</option>
@@ -111,7 +111,7 @@
         </div>
     </div>
 
-    <h2 class="blue-header">Victim's Contact Information</h2>
+    <h2 class="blue-header">Victim's Contact Information, if known</h2>
     <div class="row">
         <div class="col-12">
             <app-field label="Is the applicant's phone number(s) and email address the same or to be used for the victim?">

--- a/vsd-app/ClientApp/src/app/summary-of-benefits/benefit-list.ts
+++ b/vsd-app/ClientApp/src/app/summary-of-benefits/benefit-list.ts
@@ -242,7 +242,7 @@ export class BenefitLists {
     },
     {
       title: 'Crime scene cleaning',
-      target: 'Immediate Family Members who need specialized cleaning of the victim’s home or vehicle(if the victim is deceased), or their own home or vehicle, because the crime was committed there',
+      target: 'Immediate Family Members who need specialized cleaning of the victim’s home or vehicle (if the victim is deceased), or their own home or vehicle, because the crime was committed there',
       examples: [
         'Specialized cleaning and disinfecting of contaminated areas',
         'Replacement of contaminated flooring, wall covering, or other built-in features',


### PR DESCRIPTION
Grouping these changes in one PR as they belong to the same group of tickets:
6831: https://justice.gov.bc.ca/jira/browse/VS-6831
6832: https://justice.gov.bc.ca/jira/browse/VS-6832

Changes made:

### VS-6832:
On Landing Page when “Witness Application” is selected & on the Overview Page of the witness application (see image ii)
1. Replace the text in the existing text box with: (see image i)

"This application package is designed for a Witness of an injured or deceased victim of violent crime. Under the Crime Victim Assistance Act, a witness is a person who witnesses in close proximity a prescribed, or the immediate aftermath of a prescribed offence, that causes a life-threatening injury to, or the death of, the victim."

2. Add a second/new paragraph (NP) in the existing text box, with the following text: (see image i)

"Changes to the Crime Victim Assistance Act came into effect on January 1, 2024 and expanded the definition of Witness. If you are applying in relation to an offence that happened before January 1, 2024, the definition of Witness that was in effect at that time will apply."

3. Add a hover box at the end of the last sentence in the second/new paragraph with the following text: (see image i)

"For offences that occurred before January 1, 2024, a Witness is defined as a person who is not related to the victim but has a strong emotional attachment to the victim and witnesses in close proximity an eligible offence that causes a life-threatening injury or death to the victim or witnesses the immediate aftermath of an eligible offence that caused the death of the victim."

On the Victim Information page:
1. Change the headings in the blue banner for “Victim Information” and “Victim’s Contact Information” to the following: (see image iii)

"Victim Information, if known"

"Victim’s Contact Information, if known"

2.  the ‘First Name’, ‘Last Name’ and ‘Marital Status’ fields under the “Victim Information” heading should no longer be mandatory. (If it is problematic for these fields to not be mandatory, an “Unknown” option will have to be provided.)  (see image iii)

On the Crime Information page:
1. currently when the answer to the above question is yes (i.e. the victim is deceased) this triggers an "Additional Benefits" section to populate on the Expenses & Benefits page. We want this trigger to be removed as the same benefits are available now regardless of whether they click yes/no (see next section)

On the Expenses & Benefits page: 
1. Remove a) "Additional Benefits" header, b) the sentence below and c) the "other" category (see image vi with the lines through) NOTE: that the text box can be kept with the heading please provide details of your requests

2. Move the "Crime scene cleaning expenses" and hover icon up below the prescription drug expenses and add "expenses" to the crime scene cleaning – (see image vi) 

3. add the wording below to the hover icon for crime scene cleaning at the bottom as per arrow: (image vii)

Changes to the Crime Victim Assistance Act came into effect on January 1, 2024. If you are applying in relation to an offence that happened before January 1, 2024, the eligibility criteria for this benefit that were in effect at that time will apply.

### VS-6831
On Landing Page when “Immediate Family Member Application” is selected (image A) & on the Overview Page of the immediate family member application (see image B) make the following changes:
1. Replace the text in the existing text box with includes new paragraph (NP) as per image: (see image A)

This application package is designed for an Immediate Family Member of an injured or deceased victim of violent crime. Under the Crime Victim Assistance Act, an Immediate Family Member is a person who, at the time of the eligible offence that resulted in the death or injury of a victim, was a spouse, child, grandchild, sibling, step sibling, half sibling, parent or grandparent of the victim.

Changes to the Crime Victim Assistance Act came into effect on January 1, 2024 and expanded the definition of Immediate Family Member. If you are applying in relation to an offence that happened before January 1, 2024, the definition of Immediate Family Member that was in effect at that time will apply.

2. at the end of the second paragraph add a hover icon with the following wording and bolding: (see image A)

For offences that occurred before January 1, 2024, an Immediate Family Member is defined as a person who, at the time of the eligible offence that resulted in the death or injury of a victim, was a spouse, child, sibling, step sibling, half sibling, parent of the victim or, if financially dependent on the victim, a grandparent or grandchild of the victim.

on the link to the "Summary of Benefits" (image D1)  (please ensure that all the links to the summary in the application will reflect this update)
1. make the following changes to the crime scene cleaning wording under For (image D):

Immediate Family Members who need specialized cleaning of the victim's home or vehicle (if the victim is deceased), or their own home or vehicle, because the crime was committed there 

On the Personal Information & Address page:
1. add two additional categories to the Relationship to Victim between sibling and other:  a) Grandparent b) Grandchild (image E)

On the Expenses & Benefits page:
1. move the "Crime scene cleaning expenses" option along with the hover icon under the prescription expenses (see image F)

2. replace the wording in the  hover icon for the crime scene cleaning with the following wording (see image F)

Immediate Family Members who need specialized cleaning of the victim's home or vehicle (if the victim is deceased), or their own home or vehicle, because the crime was committed there

Examples:

Specialized cleaning and disinfecting of contaminated areas
Replacement of contaminated flooring, wall covering, or other built-in features
Changes to the Crime Victim Assistance Act came into effect on January 1, 2024. If you are applying in relation to an offence that happened before January 1, 2024, the eligibility criteria for this benefit that were in effect at that time will apply.

on the Expenses & Benefits page under Additional Benefits (note: shows when victim is selected as deceases in the crime info page)
1. In the Income Loss Information section (option displays when income support is selected) change the wording to the following (image G)

An Immediate Family Member is eligible for up to 5 days of bereavement leave benefits if the absence from work occurred within 2 years of the death of the victim or the date the Immediate Family Member became aware of the death.

2. add a hover icon to the end of the paragraph with the following text (image G)

Changes to the Crime Victim Assistance Act came into effect on January 1, 2024. If you are applying in relation to an offence that happened before January 1, 2024, the eligibility criteria for this benefit that were in effect at that time will apply.

3. under the Other Benefits header change the Aboriginal Affairs and Northern Development Canada option to: (image H)

Indigenous Services Canada

Please see JIRA tickets for images.