### PR TITLE
VS-6833

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 vsd-app/vsd-app\.sln\.DotSettings
 /.vs
+.env

--- a/vsd-app/.vscode/launch.json
+++ b/vsd-app/.vscode/launch.json
@@ -5,7 +5,7 @@
    "version": "0.2.0",
    "configurations": [
         {
-            "name": ".NET Core Launch (web)",
+            "name": "VSD App",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",

--- a/vsd-app/ClientApp/src/app/home/home.component.html
+++ b/vsd-app/ClientApp/src/app/home/home.component.html
@@ -80,13 +80,17 @@
                   </label>
                   <label>
                     <input type="radio" [value]="100000003" name="completingOnBehalfOf" formControlName="completingOnBehalfOf">
-                    A legal representative or legal guardian completing this application on behalf of someone else
+                    A legal representative or legal guardian completing this application on behalf of someone else, or
+                    <br/>
+                    <div style="padding-left: 20px">a third party completing on behalf of an incapable adult.
+                      <app-tool-tip [trigger]="legalRepresentativeTooltip"></app-tool-tip>
+                    </div>
                   </label>
                 </app-field>
               </section>
 
               <ng-template #onBehalfOfToolTip>This option should also be chosen when completing the application in consultation with a victim service worker or support person.</ng-template>
-
+              <ng-template #legalRepresentativeTooltip>If the person does not have a legal representative and is physically or mentally incapable of making the application, <strong>a third party</strong> may complete the application on their behalf. <strong>NOTE:</strong> This does not include victim service or other support workers who are providing assistance to a capable person.</ng-template>
               <section [ngClass]="form.get('wasCrimeInBC').value === false ? 'out-of-line danger-cell' : 'out-of-line'">
                 <app-field label="Did the crime occur in BC" [required]="true">
                   <table style="width: 100%" class="out-of-line">

--- a/vsd-app/ClientApp/src/app/quick-exit/quick-exit.component.scss
+++ b/vsd-app/ClientApp/src/app/quick-exit/quick-exit.component.scss
@@ -1,5 +1,6 @@
 .slide-close {
   position: fixed;
+  cursor: pointer;
   bottom: 20px;
   left: 0;
   background-color: #f1dede;

--- a/vsd-app/ClientApp/src/app/shared/authorization-information/authorization-information.component.html
+++ b/vsd-app/ClientApp/src/app/shared/authorization-information/authorization-information.component.html
@@ -2,6 +2,9 @@
   <div class="page-header">
     <h1>Authorization and Consent</h1>
   </div>
+  <div class="attention">
+    <p>The authorization and consents requested below can only be provided by a person completing their own application, a parent completing the application for their minor child, a legal representative or a legal guardian. If you are any other person completing the application on behalf of another, please enter “N/A” in the required fields below.</p>
+  </div>
   <p>Section 6 of the <i>Crime Victim Assistance Act</i> allows the Crime Victim Assistance Program to collect your personal information from persons and organizations for the purpose of determining your eligibility for benefits and provides the authority for these organizations to disclose your personal information to Crime Victim Assistance Program for the same purpose.</p>
   <p>By signing below, I am authorizing the Crime Victim Assistance Program to request a report or information from a medical practitioner, a health professional, an expert and/or one or more of the third parties listed below. I am also consenting to the Crime Victim Assistance Program contacting these third parties to seek verification of the medical, financial, or other employment information I have provided. I understand that the Crime Victim Assistance Program may contact and seek or verify information from these parties for the purpose of determining my eligibility for benefits:</p>
 
@@ -13,8 +16,7 @@
       <li><span>The Workers' Compensation Board of BC or other authority from which I received or will receive or will be eligible to receive payments from provincial, federal or other jurisdictions funds, to obtain information relevant to this application;</span></li>
       <li><span>My employer(s) or similar authority, to obtain information as to my employment, earnings, benefits or other information relevant to this application;</span></li>
       <li><span>Any accident, disability, sickness, life insurance/assurance company or private pension scheme or extended health benefits scheme from which payments or services were received or will be received, to obtain information relevant to this application;</span></li>
-      <li><span>Human Resources and Skills Development Canada or Indigenous Services Canada or any other authority from which payments were received or will be received, to obtain information relevant to this application;</span></li>
-      <li><span>The Canada Employment Insurance Commission or the Canada Pension Plan or similar employment insurance and pension plans from other jurisdiction to obtain information as to benefits received or to be received relevant to this application;</span></li>
+      <li><span>Employment and Social Development Canada, Indigenous Services Canada or any other authority from which payments were received or will be received, to obtain information relevant to this application;</span></li>
       <li><span>Canada Revenue Agency or other similar agency in any jurisdiction to obtain information as to my employment income.</span></li>
       <li><span>The Ministry of Children and Family Development to obtain information relevant to this application.</span></li>
     </ol>

--- a/vsd-app/ClientApp/src/app/shared/declaration-information/declaration-information.component.html
+++ b/vsd-app/ClientApp/src/app/shared/declaration-information/declaration-information.component.html
@@ -3,7 +3,7 @@
         <h1>Declaration</h1>
     </div>
     <h2 class="blue-header">Information Collection Notice</h2>
-    <p>The Crime Victim Assistance Program will collect your personal information for the purpose of providing you with victim services and determine your eligibility for benefits in accordance with sections 26(a) and (c) of the <i>Freedom of Information and Protection of Privacy Act</i> (FoIPPA), and the <i>Crime Victim Assistance Act</i>. Your personal information may also be collected as per section 26(e) of FoIPPA in order to evaluate the program to better serve you.</p>
+    <p>The Crime Victim Assistance Program collects personal information for the purpose of providing victim services and determining eligibility for benefits in accordance with sections 26(a) and (c) of the <i>Freedom of Information and Protection of Privacy Act</i> (FoIPPA), and the <i>Crime Victim Assistance Act</i>. Personal information may also be collected as per section 26(e) of FoIPPA in order to evaluate the program to better serve applicants.</p>
     <p>Should you have any questions about the collection, use, or disclosure of personal information, please contact the Crime Victim Assistance Program at <a [href]="'mailto: ' + cvapEmail">{{cvapEmail}}</a> or by phone at (604) 660-3888 and toll free at 1-800-660-3888 or at PO Box 5550, Stn Terminal, Vancouver, BC, V6B1H1.</p>
     <section>
         <h2 class="blue-header">Declaration & Signature</h2>

--- a/vsd-app/ClientApp/src/app/shared/enums-list.ts
+++ b/vsd-app/ClientApp/src/app/shared/enums-list.ts
@@ -138,7 +138,7 @@ export class EnumHelper {
     100000000: 'Completing this application for myself',
     100000001: 'A Victim Service Worker or other person helping a victim complete this application',
     100000002: 'A parent completing this application for my minor child (under 19 years of age)',
-    100000003: 'A legal representative or legal guardian completing this application on behalf of someone else',
+    100000003: 'A legal representative or legal guardian completing this application on behalf of someone else, or a third party completing on behalf of an incapable adult.',
   }
 
   public ProviderSpecialistType = {

--- a/vsd-app/ClientApp/src/app/shared/personal-information/personal-information.component.html
+++ b/vsd-app/ClientApp/src/app/shared/personal-information/personal-information.component.html
@@ -173,7 +173,7 @@
     </div>
 
     <div class="attention">
-        <p>Please note that your answers to questions about demographic information (e.g. gender, Indigenous identity) allow the Community Safety and Crime Prevention branch to better understand who accesses our programs so we may continue to improve our service delivery. Your response is voluntary and the information you provide does not impact your ability to access these services.</p>
+        <p>Please note that your answers to questions about demographic information (e.g., gender, Indigenous identity) allow the Community Safety and Victim Services branch to better understand who accesses our programs so we may continue to improve service delivery. Your response is voluntary and the information you provide does not impact your ability to access these services.</p>
     </div>
 
     <h2 class="blue-header">Contact Information</h2>

--- a/vsd-app/ClientApp/src/app/shared/representative-information/representative-information.component.html
+++ b/vsd-app/ClientApp/src/app/shared/representative-information/representative-information.component.html
@@ -3,7 +3,7 @@
     <h1>Application on Behalf of {{header}}</h1>
   </div>
 
-  <p>This section provides information regarding applying on behalf of an applicant. This information is only necessary if you are a guardian or legal representative of the applicant.</p>
+  <p>This section provides information regarding applying on behalf of an applicant.</p>
   <div class="attention" *ngIf="form.get('completingOnBehalfOf').value === originalOnBehalfOf">
     <p>You previously selected the option below. Verify that this is correct before continuing with the application.</p>
   </div>
@@ -24,11 +24,15 @@
 
       <label>
         <input type="radio" [value]="100000003" name="completingOnBehalfOf" formControlName="completingOnBehalfOf">
-        A legal representative or legal guardian completing this application on behalf of someone else
+        A legal representative or legal guardian completing this application on behalf of someone else, or
+        <br/>
+        <div style="padding-left: 20px">a third party completing on behalf of an incapable adult.
+          <app-tool-tip [trigger]="legalRepresentativeTooltip"></app-tool-tip>
+        </div>
       </label>
     </app-field>
   </section>
-
+  <ng-template #legalRepresentativeTooltip>If the person does not have a legal representative and is physically or mentally incapable of making the application, <strong>a third party</strong> may complete the application on their behalf. <strong>NOTE:</strong> This does not include victim service or other support workers who are providing assistance to a capable person.</ng-template>
   <div class="row" *ngIf="form.get('completingOnBehalfOf').value === 100000003">
     <div class="col-md-6">
       <app-field label="Relationship to Person" [required]="true" errorMessage="Please select a relationship" [valid]="isMyControlValid(form.get('relationshipToPerson'))">
@@ -147,7 +151,7 @@
     </div>
 
     <ng-container *ngIf="form.get('completingOnBehalfOf').value === 100000003">
-      <h2 class="blue-header">Proof of Legal Authority</h2>
+      <h2 class="blue-header">Proof of Legal Authority, If Applicable</h2>
       <p>Note: The Crime Victim Assistance Program requires proof of your authority to apply for benefits on behalf of the applicant. Please attach the legal documentation here.
         <strong>File size limit:</strong> one file cannot exceed 2MB and all files uploaded to application cannot exceed 3.5MB
       </p>


### PR DESCRIPTION
Background: There has been some changes to CVAP legislation that requires changes to the web application as well as some updates to reflect current names of organizations.

All the following changes need to be made on the Victim, Immediate Family Member and Witness applications (3 applications):

on Landing Page and on the Application on Behalf Of page (make changes on both pages on all three applications)
1. replace the 3rd option with the following wording: (see image 3)

A legal representative or legal guardian completing this application on behalf of someone else, or a third party completing on behalf of an incapable adult.

2.  add a hover icon to the third bullet with the following text (see image 3)

If the person does not have a legal representative and is physically or mentally incapable of making the application, a third party may complete the application on their behalf. NOTE: This does not include victim service or other support workers who are providing assistance to a capable person.

on the Victim Information & Address page (victim app) as well as to the Personal Information & Addresses pages (ifm/witness app)
1. replace the wording in the text box with the following (note: only changing Crime Prevention branch to Victim Services branch- if that is easier to change) (image 4)

Please note that your answers to questions about demographic information (e.g., gender, Indigenous identity) allow the Community Safety and Victim Services branch to better understand who accesses our programs so we may continue to improve service delivery. Your response is voluntary and the information you provide does not impact your ability to access these services.

on the Application on Behalf of "victim", "immediate family", "witness" pages (3 places) 
1. delete the wording "This information is only necessary if you are a guardian or legal representative" (see image 6)

2. add another option to the Relationship to Person dropdown called "Third party applying on behalf of an incapable adult" (see image 7)

3.  When the legal representative is selected in the Proof of Legal Authority header change to: (see image 8)

Proof of Legal Authority, if applicable

on the Declaration page (of victim, immediate family and witness applications):
1. replace the first paragraph with the following (see image 9)

The Crime Victim Assistance Program collects personal information for the purpose of providing victim services and determining eligibility for benefits in accordance with sections 26(a) and (c) of the Freedom of Information and Protection of Privacy Act (FoIPPA), and the Crime Victim Assistance Act. Personal information may also be collected as per section 26(e) of FoIPPA in order to evaluate the program to better serve applicants.

on the Authorization page (of victim, immediate family and witness applications):
1. Under the heading “Authorization and Consent” add a coloured text box (similar to all other light blue text boxes throughout application – see example in image 4, though the colouring only appears very faintly) with the following text: (see image 10)

The authorization and consents requested below can only be provided by a person completing their own application, a parent completing the application for their minor child, a legal representative or a legal guardian. If you are any other person completing the application on behalf of another, please enter “N/A” in the required fields below.

2. replace existing paragraph 6 with the following wording (see image 11)

Employment and Social Development Canada, Indigenous Services Canada or any other authority from which payments were received or will be received, to obtain information relevant to this application;