### PR TITLE
VS-6604: Add "0" to end of 8-digit Claim Number

### DIFF
--- a/vsd-app/ClientApp/src/app/submit-invoice/submit-invoice.component.html
+++ b/vsd-app/ClientApp/src/app/submit-invoice/submit-invoice.component.html
@@ -112,7 +112,7 @@
                 <div class="row">
                   <div class="col-6">
                     <app-field label="Claim Number" [required]="true" [valid]="isFieldValid('invoiceDetails.claimNumber')" errorMessage="Please enter the claim number">
-                      <input class="form-control" mask="00-00000-00" minlength="7" [dropSpecialCharacters]="false" [validation]="false" type="text" formControlName="claimNumber" maxlength="100">
+                      <input class="form-control" mask="00-00000-00" minlength="10" [dropSpecialCharacters]="false" [validation]="false" type="text" formControlName="claimNumber" maxlength="11">
                     </app-field>
                   </div>
                 </div>

--- a/vsd-app/ClientApp/src/app/submit-invoice/submit-invoice.component.ts
+++ b/vsd-app/ClientApp/src/app/submit-invoice/submit-invoice.component.ts
@@ -320,6 +320,9 @@ export class SubmitInvoiceComponent extends FormBase implements OnInit {
         InvoiceDetails: this.form.get('invoiceDetails').value,
       };
       formData.InvoiceDetails.exemptFromGst = !formData.InvoiceDetails.gstApplicable;
+      if (formData.InvoiceDetails.claimNumber.length === 10) {
+        formData.InvoiceDetails.claimNumber += "0";
+      }
 
       this.getInvoicePDF(formData).then((pdfs: DocumentCollectioninformation[]) => {
         formData.DocumentCollection = pdfs;


### PR DESCRIPTION
Waiting on confirmation from Candice Lee that this is the correct place to apply the fix. If it is, this is an easy 2-liner.

https://justice.gov.bc.ca/cvapwebform/submit-invoice

When submitting some specific invoices from the above url, received the error:

Error submitting invoice. undefined (see attachment)

Note

this does not happen on all submissions
submitting of the following records failed: 
[Case: Pensions: 22-37908-2-IFM-Gendron, Ryan Joseph ](https://cscp-vs.jag.gov.bc.ca/main.aspx?appid=8db8d56e-d06e-ea11-b815-005056836bf0&pagetype=entityrecord&etn=incident&id=1827b364-8ca1-ed11-b831-005056832755)
[Case: Pensions: 22-33795-1-IFM-Pedersen, Austin Richard James](https://cscp-vs.jag.gov.bc.ca/main.aspx?appid=8db8d56e-d06e-ea11-b815-005056836bf0&pagetype=entityrecord&etn=incident&id=77803110-dc9b-ec11-b828-005056832755)
[Case: Pensions: 22-63647-2-IFM-Miller, Lilee ](https://cscp-vs.jag.gov.bc.ca/main.aspx?appid=8db8d56e-d06e-ea11-b815-005056836bf0&pagetype=entityrecord&etn=incident&id=c327961e-d82e-ed11-b82b-005056832174)
[Case: Pensions: 22-62522-1-IFM-Draper, Arwen](https://cscp-vs.jag.gov.bc.ca/main.aspx?appid=8db8d56e-d06e-ea11-b815-005056836bf0&pagetype=entityrecord&etn=incident&id=5332e6ff-1523-ed11-b82b-005056832755)
These cases are in common that they have an original VSD #, but such # is changed when the case is linked to a victim
 

Recent (Jan 25/24) example of web invoice that can into Coast on an IFM [Invoice: CVAP Main: INV-2024-065549 - Dynamics 365 (gov.bc.ca)](https://cscp-vs.jag.gov.bc.ca/main.aspx?appid=8db8d56e-d06e-ea11-b815-005056836bf0&pagetype=entityrecord&etn=vsd_invoice&id=2747865e-4d7d-4871-99bb-659711418bd2)


