### PR TITLE
VS-6797: Upgrade backend to .NET 8 & Updated Application to Headless Architecture

### DIFF
--- a/.github/workflows/cd-vsd.yml
+++ b/.github/workflows/cd-vsd.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Pull image
         run: docker pull $IMAGE_ID || true
 
-      - name: Build and push vsu-app
+      - name: Build and push vsd-app
         uses: docker/build-push-action@v6
         with:
           build-args: |
@@ -72,7 +72,7 @@ jobs:
       - name: Pull image
         run: docker pull $IMAGE_ID || true
 
-      - name: Build and push vsu-app
+      - name: Build and push vsd-app
         uses: docker/build-push-action@v6
         with:
           build-args: |

--- a/.github/workflows/cd-vsd.yml
+++ b/.github/workflows/cd-vsd.yml
@@ -1,0 +1,85 @@
+name: cd-vsd-app
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'vsd-app/**'
+      - 'vsd-interfaces/**'
+      - '.github/workflows/cd-vsd.yml'
+
+env:
+  APP_NAME: vsd
+  BUILD_ID: ${{ github.server_url }}!${{ github.repository }}!${{ github.ref_name }}!${{ github.sha }}!${{ github.run_number }}
+  IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
+
+jobs:
+  build-vsd-api:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bcgov'
+    env:
+      IMAGE_NAME: api
+      VSD_API_DOCKERFILE_PATH: ./vsd-app/Dockerfile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx tooling
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into OpenShift Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ secrets.OCP4_USERNAME }}
+          password: ${{ secrets.OCP4_PASSWORD }}
+
+      - name: Pull image
+        run: docker pull $IMAGE_ID || true
+
+      - name: Build and push vsu-app
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            BUILD_ID="${{ env.BUILD_ID }}"
+          cache-from: |
+            ${{ env.IMAGE_REGISTRY }}/${{ env.APP_NAME }}-${{ env.IMAGE_NAME }}
+          file: ${{ env.VSD_API_DOCKERFILE_PATH }}
+          push: true
+          tags: |
+            ${{ env.IMAGE_REGISTRY }}/${{ env.APP_NAME }}-${{ env.IMAGE_NAME }}:dev
+
+  build-vsd-ui:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bcgov'
+    env:
+      IMAGE_NAME: ui
+      VSD_UI_DOCKERFILE_PATH: ./vsd-app/ClientApp/Dockerfile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx tooling
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into OpenShift Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ secrets.OCP4_USERNAME }}
+          password: ${{ secrets.OCP4_PASSWORD }}
+
+      - name: Pull image
+        run: docker pull $IMAGE_ID || true
+
+      - name: Build and push vsu-app
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            BUILD_ID="${{ env.BUILD_ID }}"
+          cache-from: |
+            ${{ env.IMAGE_REGISTRY }}/${{ env.APP_NAME }}-${{ env.IMAGE_NAME }}
+          file: ${{ env.VSD_UI_DOCKERFILE_PATH }}
+          push: true
+          tags: |
+            ${{ env.IMAGE_REGISTRY }}/${{ env.APP_NAME }}-${{ env.IMAGE_NAME }}:dev

--- a/.github/workflows/pull_request_template.md
+++ b/.github/workflows/pull_request_template.md
@@ -1,0 +1,27 @@
+## Description
+
+<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
+
+:information_source: [**Jira Ticket Number here**](Jira web address here)  
+
+* List changes here
+
+## Type of change
+
+<!-- Please delete options that are not relevant. -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## Checklist
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/vsd-app/ClientApp/Caddyfile
+++ b/vsd-app/ClientApp/Caddyfile
@@ -17,7 +17,7 @@
 		# Disallow the site to be rendered within a frame (clickjacking protection)
 		X-Frame-Options "DENY"
 		# Set CSP to support Angular
-		Content-Security-Policy "default-src 'self' 'unsafe-eval' https://*.gov.bc.ca https://*.bcgov https://localhost:5020;base-uri 'self';connect-src 'self' https://*.gov.bc.ca; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; form-action 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; frame-src 'self' https://*.gov.bc.ca; frame-ancestors 'self' https://*.gov.bc.ca; upgrade-insecure-requests"
+		Content-Security-Policy "default-src 'self'; script-src 'self' https://apis.google.com https://maxcdn.bootstrapcdn.com https://cdnjs.cloudflare.com https://code.jquery.com https://stackpath.bootstrapcdn.com https://fonts.googleapis.com; object-src 'self' data:; style-src 'self' 'unsafe-inline' https://use.fontawesome.com https://stackpath.bootstrapcdn.com https://fonts.googleapis.com;img-src 'self' data:; frame-src 'self' data:;font-src 'self' https://use.fontawesome.com https://fonts.gstatic.com; form-action 'self'; frame-ancestors 'self'; block-all-mixed-content"
 		# Set referrer policy
 		Referrer-Policy "same-origin"
   	}

--- a/vsd-app/ClientApp/Caddyfile
+++ b/vsd-app/ClientApp/Caddyfile
@@ -1,0 +1,37 @@
+{
+	admin off
+}
+
+:2015 {
+	log stdout
+
+	root * /site
+
+	header {
+  		# Enable HTTP Strict Transport Security (HSTS) to force clients to always connect via HTTPS (do not use if only testing)
+  		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+  		# Enable cross-site filter (XSS) and tell browser to block detected attacks
+  		X-XSS-Protection "1; mode=block"
+  		# Prevent some browsers from MIME-sniffing a response away from the declared Content-Type
+  		X-Content-Type-Options "nosniff"
+		# Disallow the site to be rendered within a frame (clickjacking protection)
+		X-Frame-Options "DENY"
+		# Set CSP to support Angular
+		Content-Security-Policy "default-src 'self' 'unsafe-eval' https://*.gov.bc.ca https://*.bcgov https://localhost:5020;base-uri 'self';connect-src 'self' https://*.gov.bc.ca; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; form-action 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; frame-src 'self' https://*.gov.bc.ca; frame-ancestors 'self' https://*.gov.bc.ca; upgrade-insecure-requests"
+		# Set referrer policy
+		Referrer-Policy "same-origin"
+  	}
+
+	encode zstd gzip
+
+	route {
+		@jstype path *.js
+    	header @jstype Content-Type text/javascript
+
+		uri strip_prefix {$BASE_URL}
+		reverse_proxy /api* {$API_URL}
+		try_files {path} {path}/ /index.html?{query}
+	}
+
+	file_server
+}

--- a/vsd-app/ClientApp/Dockerfile
+++ b/vsd-app/ClientApp/Dockerfile
@@ -1,5 +1,5 @@
 # Create build image layer
-FROM node:8.9.4 as build
+FROM node:8.9.4 AS build
 
 COPY ./vsd-app/ClientApp ./vsd-app/ClientApp
 
@@ -9,7 +9,7 @@ RUN npm install
 RUN npm run build -- --base-href /cvapwebform --prod
 
 # Create runtime image layer, copy build image contents into this image
-FROM caddy:latest as final
+FROM caddy:latest AS final
 COPY ./vsd-app/ClientApp/Caddyfile /etc/caddy/Caddyfile
 COPY --from=build /vsd-app/ClientApp/dist/ /site
 ENV BASE_URL=

--- a/vsd-app/ClientApp/Dockerfile
+++ b/vsd-app/ClientApp/Dockerfile
@@ -1,21 +1,17 @@
-# matches the node version used by openshift S2i image
-FROM node:10 as node
+# Create build image layer
+FROM node:8.9.4 as build
 
-WORKDIR /usr/src/app
+COPY ./vsd-app/ClientApp ./vsd-app/ClientApp
 
-# install a specific NPM version
-RUN npm install -g npm@6.10.3
+WORKDIR /vsd-app/ClientApp
 
-# copy package and package-lock
-COPY package*.json ./
+RUN npm install
+RUN npm run build -- --base-href /cvapwebform --prod
 
-# run npm as continuous integration (Fetches dependencies every build.)
-RUN npm ci
-
-COPY . .
-
-# ng serve (4200)
-# webpack hot module reload (49153)
-EXPOSE 4200 49153
-
-CMD ["npm", "start", "--", "--poll=500"]
+# Create runtime image layer, copy build image contents into this image
+FROM caddy:latest as final
+COPY ./vsd-app/ClientApp/Caddyfile /etc/caddy/Caddyfile
+COPY --from=build /vsd-app/ClientApp/dist/ /site
+ENV BASE_URL=
+ENV API_URL=
+EXPOSE 2015

--- a/vsd-app/Dockerfile
+++ b/vsd-app/Dockerfile
@@ -1,0 +1,32 @@
+#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+ARG BUILD_ID
+
+# Retrieve and set base image layer
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+ARG BUILD_ID
+ARG BUILD_VERSION
+WORKDIR /app
+
+# Create build image for runtime
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+COPY . .
+
+# Restore as distinct layers
+RUN dotnet restore ./vsd-app/
+RUN dotnet build "vsd-app/vsd-app.csproj" -c Release -o /app/build
+
+# Create publish image layer
+FROM build AS publish
+ARG BUILD_ID
+COPY . .
+
+# Build and publish a release
+RUN dotnet publish ./vsd-app -c Release -o /app/publish
+
+# Build runtime image
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://*:8080
+ENTRYPOINT ["dotnet", "vsd-app.dll"]

--- a/vsd-app/vsd-app.csproj
+++ b/vsd-app/vsd-app.csproj
@@ -18,30 +18,30 @@
 		<PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
 		<PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
 		<PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-		<PackageReference Include="NWebsec.AspNetCore.Middleware" Version="2.0.0" />
-		<PackageReference Include="NWebsec.AspNetCore.Mvc" Version="2.0.0" />
-		<PackageReference Include="NWebsec.AspNetCore.Mvc.TagHelpers" Version="2.0.0" />
-		<PackageReference Include="Serilog" Version="2.10.0" />
-		<PackageReference Include="Serilog.Exceptions" Version="5.6.0" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-		<PackageReference Include="Serilog.Sinks.Splunk" Version="3.6.0" />
-		<PackageReference Include="xunit" Version="2.4.0" />
-		<PackageReference Include="xunit.runner.console" Version="2.4.0">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+		<PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
+		<PackageReference Include="NWebsec.AspNetCore.Mvc" Version="3.0.0" />
+		<PackageReference Include="NWebsec.AspNetCore.Mvc.TagHelpers" Version="3.0.0" />
+		<PackageReference Include="Serilog" Version="4.0.1" />
+		<PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+		<PackageReference Include="Serilog.Sinks.Splunk" Version="5.0.1" />
+		<PackageReference Include="xunit" Version="2.9.0" />
+		<PackageReference Include="xunit.runner.console" Version="2.9.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.2" />
-		<PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.2" />
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="System.Text.Json" Version="8.0.2" />
+		<PackageReference Include="System.Text.Json" Version="8.0.4" />
 	</ItemGroup>
 	<ItemGroup>
 		<!-- Don't publish the SPA source files, but do show them in the project files list -->
@@ -126,22 +126,5 @@
 		<Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
 		<Message Importance="high" Text="Restoring dependencies using 'npm'. This may take several minutes..." />
 		<Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
-	</Target>
-	<Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
-		<!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
-		<Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
-		<Exec WorkingDirectory="$(SpaRoot)" Command="npm run build -- --prod" Condition="'$(UAT_BUILD)' == '' And '$(PROD_BUILD)' == ''" />
-		<Exec WorkingDirectory="$(SpaRoot)" Command="npm run builduat -- --prod" Condition="'$(UAT_BUILD)' == '1'" />
-		<Exec WorkingDirectory="$(SpaRoot)" Command="npm run buildprod -- --prod" Condition="'$(PROD_BUILD)' == '1'" />
-		<Exec WorkingDirectory="$(SpaRoot)" Command="npm run build:ssr -- --prod" Condition=" '$(BuildServerSideRenderer)' == 'true' " />
-		<!-- Include the newly-built files in the publish output -->
-		<ItemGroup>
-			<DistFiles Include="$(SpaRoot)dist\**; $(SpaRoot)dist-server\**" />
-			<DistFiles Include="$(SpaRoot)node_modules\**" Condition="'$(BuildServerSideRenderer)' == 'true'" />
-			<ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
-				<RelativePath>%(DistFiles.Identity)</RelativePath>
-				<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-			</ResolvedFileToPublish>
-		</ItemGroup>
 	</Target>
 </Project>


### PR DESCRIPTION
## Background
To resolve vulnerabilities identified in the existing .NET base image, `vsd`'s backend was updated to .NET 8 and its related dependencies were updated to versions compatible with the respective .NET version. However, during this process, efforts were made to also reduce and simplify the image creation process. This was achieved by migrating the existing `s2i` process to Docker. 

However, the existing Angular version (`7`) and underlying Node version (`8.9.4`) were outdated and no Microsoft .NET 8 SDK image existed that could support these legacy versions. To resolve this, the decision was made to transition `vsd`'s monolithic architecture to a modern headless architecture (the frontend and backend are separate layers). This enables the backend to be updated without having to introduce additional scope from updating the front-end, which should be updated a later date.

## Associated Ticket
[VS-6797](https://jag.gov.bc.ca/jira/browse/VS-6797)

## Checklist
- [x] Create a `Dockerfile` for each application service layer
  - [x] `vsd-app/ClientApp` (frontend)
  - [x] `vsd-app` (backend)
- [x] Update .NET project and solution files to not include nor track frontend code
- [x] Update documentation