### PR TITLE
feat: reapply postal/zip code validators after loading draft data in …

### DIFF
--- a/vsd-app/ClientApp/src/app/ifm-application/ifm-application.component.ts
+++ b/vsd-app/ClientApp/src/app/ifm-application/ifm-application.component.ts
@@ -28,6 +28,7 @@ import {
 import { AEMService } from '../services/aem.service';
 import { LoginService } from '../services/login.service';
 import { StateService } from '../services/state.service';
+import { AddressHelper } from '../shared/address/address.helper';
 import { AuthInfoHelper } from '../shared/authorization-information/authorization-information.helper';
 import { CrimeInfoHelper } from '../shared/crime-information/crime-information.helper';
 import { DeclarationInfoHelper } from '../shared/declaration-information/declaration-information.helper';
@@ -479,6 +480,10 @@ export class IfmApplicationComponent extends FormBase implements OnInit, OnDestr
     );
 
     this.form.patchValue(savedData, { emitEvent: false });
+
+    // Re-apply postal/zip code validators based on the restored country values, since
+    // patchValue with emitEvent:false does not trigger the country-change handlers.
+    this.reapplyPostalCodeValidators();
   }
 
   /** Ensure a FormArray has the correct number of items to accept patchValue data. */
@@ -498,6 +503,36 @@ export class IfmApplicationComponent extends FormBase implements OnInit, OnDestr
     while (formArray.length > savedArray.length) {
       formArray.removeAt(formArray.length - 1);
     }
+  }
+
+  /** Re-apply the correct postal/zip code validator for every address in the form based on the
+   *  restored country value. This is needed after loading a draft because patchValue with
+   *  emitEvent:false does not trigger the country-change handlers that normally update validators. */
+  private reapplyPostalCodeValidators(): void {
+    const addressHelper = new AddressHelper();
+
+    const simpleAddressPaths = [
+      'personalInformation.primaryAddress',
+      'personalInformation.alternateAddress',
+      'victimInformation.primaryAddress',
+      'representativeInformation.representativeAddress',
+      'crimeInformation.racafInformation.lawyerAddress',
+      'medicalInformation.familyDoctorAddress'
+    ];
+
+    for (const path of simpleAddressPaths) {
+      addressHelper.updatePostalCodeValidatorByCountry(this.form.get(path) as UntypedFormGroup);
+    }
+
+    const treatmentsArray = this.form.get('medicalInformation.otherTreatments') as UntypedFormArray;
+    treatmentsArray?.controls.forEach((ctrl) =>
+      addressHelper.updatePostalCodeValidatorByCountry(ctrl.get('providerAddress') as UntypedFormGroup)
+    );
+
+    const authorizedPersonsArray = this.form.get('authorizationInformation.authorizedPerson') as UntypedFormArray;
+    authorizedPersonsArray?.controls.forEach((ctrl) =>
+      addressHelper.updatePostalCodeValidatorByCountry(ctrl.get('authorizedPersonAgencyAddress') as UntypedFormGroup)
+    );
   }
 
   private buildApplicationForm(FORM: ApplicationType = this.FORM_TYPE): UntypedFormGroup {

--- a/vsd-app/ClientApp/src/app/shared/address/address.helper.ts
+++ b/vsd-app/ClientApp/src/app/shared/address/address.helper.ts
@@ -1,6 +1,6 @@
-import { POSTAL_CODE, ZIP_CODE } from '../regex.constants';
 import { UntypedFormGroup, Validators } from '@angular/forms';
 import { Address } from '../../interfaces/address.interface';
+import { POSTAL_CODE, ZIP_CODE } from '../regex.constants';
 
 export class AddressHelper {
   postalRegex = POSTAL_CODE;
@@ -78,6 +78,35 @@ export class AddressHelper {
     }
     // postalControl.markAsTouched();
     postalControl.updateValueAndValidity(options);
+  }
+
+  /**
+   * Updates only the postalCode validator on an address FormGroup based on its current country value.
+   * Preserves any existing Validators.required on the postal code control.
+   * Call this after restoring draft data to ensure the correct postal/zip pattern is applied.
+   */
+  public updatePostalCodeValidatorByCountry(addressGroup: UntypedFormGroup): void {
+    if (!addressGroup) return;
+    const postalControl = addressGroup.get('postalCode');
+    if (!postalControl) return;
+
+    const country: string = addressGroup.get('country')?.value ?? '';
+    const isRequired = postalControl.hasValidator(Validators.required);
+
+    if (country === 'Canada') {
+      postalControl.setValidators(
+        isRequired
+          ? [Validators.required, Validators.pattern(this.postalRegex)]
+          : [Validators.pattern(this.postalRegex)]
+      );
+    } else if (country === 'United States of America') {
+      postalControl.setValidators(
+        isRequired ? [Validators.required, Validators.pattern(this.zipRegex)] : [Validators.pattern(this.zipRegex)]
+      );
+    } else {
+      postalControl.setValidators(isRequired ? [Validators.required] : null);
+    }
+    postalControl.updateValueAndValidity({ emitEvent: false });
   }
 
   public hasAddressInfo(address: Address) {

--- a/vsd-app/ClientApp/src/app/victim-application/victim-application.component.ts
+++ b/vsd-app/ClientApp/src/app/victim-application/victim-application.component.ts
@@ -27,6 +27,7 @@ import {
 import { AEMService } from '../services/aem.service';
 import { LoginService } from '../services/login.service';
 import { StateService } from '../services/state.service';
+import { AddressHelper } from '../shared/address/address.helper';
 import { AuthInfoHelper } from '../shared/authorization-information/authorization-information.helper';
 import { CrimeInfoHelper } from '../shared/crime-information/crime-information.helper';
 import { DeclarationInfoHelper } from '../shared/declaration-information/declaration-information.helper';
@@ -490,6 +491,20 @@ export class VictimApplicationComponent extends FormBase implements OnInit, OnDe
         });
     } else {
       this.submitting = false;
+      const findInvalidControls = (group: UntypedFormGroup | UntypedFormArray, path = ''): void => {
+        Object.keys(group.controls).forEach((key) => {
+          const control = (group as any).controls[key];
+          const controlPath = path ? `${path}.${key}` : key;
+          if (control.invalid) {
+            if (control instanceof UntypedFormGroup || control instanceof UntypedFormArray) {
+              findInvalidControls(control, controlPath);
+            } else {
+              console.warn('Invalid control:', controlPath, control.errors);
+            }
+          }
+        });
+      };
+      findInvalidControls(this.form);
     }
   }
 
@@ -676,13 +691,17 @@ export class VictimApplicationComponent extends FormBase implements OnInit, OnDe
     this.resizeFormArray('representativeInformation', 'documents', savedData, () =>
       this.fb.group({ filename: [''], body: [''], subject: [''], size: [0] })
     );
-    
+
     const empInfo = savedData?.employmentIncomeInformation;
     if (empInfo != null && empInfo.haveYouAppliedToWorkSafe != null && empInfo.haveYouAppliedToWorkSafe !== '') {
       empInfo.haveYouAppliedForWorkersCompensation = empInfo.haveYouAppliedToWorkSafe;
     }
 
     this.form.patchValue(savedData, { emitEvent: false });
+
+    // Re-apply postal/zip code validators based on the restored country values, since
+    // patchValue with emitEvent:false does not trigger the country-change handlers.
+    this.reapplyPostalCodeValidators();
   }
 
   /** Ensure a FormArray has the correct number of items to accept patchValue data. */
@@ -703,6 +722,40 @@ export class VictimApplicationComponent extends FormBase implements OnInit, OnDe
     while (formArray.length > savedArray.length) {
       formArray.removeAt(formArray.length - 1);
     }
+  }
+
+  /** Re-apply the correct postal/zip code validator for every address in the form based on the
+   *  restored country value. This is needed after loading a draft because patchValue with
+   *  emitEvent:false does not trigger the country-change handlers that normally update validators. */
+  private reapplyPostalCodeValidators(): void {
+    const addressHelper = new AddressHelper();
+
+    const simpleAddressPaths = [
+      'personalInformation.primaryAddress',
+      'personalInformation.alternateAddress',
+      'representativeInformation.representativeAddress',
+      'crimeInformation.racafInformation.lawyerAddress',
+      'medicalInformation.familyDoctorAddress'
+    ];
+
+    for (const path of simpleAddressPaths) {
+      addressHelper.updatePostalCodeValidatorByCountry(this.form.get(path) as UntypedFormGroup);
+    }
+
+    const treatmentsArray = this.form.get('medicalInformation.otherTreatments') as UntypedFormArray;
+    treatmentsArray?.controls.forEach((ctrl) =>
+      addressHelper.updatePostalCodeValidatorByCountry(ctrl.get('providerAddress') as UntypedFormGroup)
+    );
+
+    const employersArray = this.form.get('employmentIncomeInformation.employers') as UntypedFormArray;
+    employersArray?.controls.forEach((ctrl) =>
+      addressHelper.updatePostalCodeValidatorByCountry(ctrl.get('employerAddress') as UntypedFormGroup)
+    );
+
+    const authorizedPersonsArray = this.form.get('authorizationInformation.authorizedPerson') as UntypedFormArray;
+    authorizedPersonsArray?.controls.forEach((ctrl) =>
+      addressHelper.updatePostalCodeValidatorByCountry(ctrl.get('authorizedPersonAgencyAddress') as UntypedFormGroup)
+    );
   }
 
   markAsTouched() {

--- a/vsd-app/ClientApp/src/app/witness-application/witness-application.component.ts
+++ b/vsd-app/ClientApp/src/app/witness-application/witness-application.component.ts
@@ -27,6 +27,7 @@ import {
 } from '../interfaces/application.interface';
 import { AEMService } from '../services/aem.service';
 import { LoginService } from '../services/login.service';
+import { AddressHelper } from '../shared/address/address.helper';
 import { AuthInfoHelper } from '../shared/authorization-information/authorization-information.helper';
 import { CrimeInfoHelper } from '../shared/crime-information/crime-information.helper';
 import { DeclarationInfoHelper } from '../shared/declaration-information/declaration-information.helper';
@@ -439,6 +440,10 @@ export class WitnessApplicationComponent extends FormBase implements OnInit, OnD
     );
 
     this.form.patchValue(savedData, { emitEvent: false });
+
+    // Re-apply postal/zip code validators based on the restored country values, since
+    // patchValue with emitEvent:false does not trigger the country-change handlers.
+    this.reapplyPostalCodeValidators();
   }
 
   /** Ensure a FormArray has the correct number of items to accept patchValue data. */
@@ -458,6 +463,36 @@ export class WitnessApplicationComponent extends FormBase implements OnInit, OnD
     while (formArray.length > savedArray.length) {
       formArray.removeAt(formArray.length - 1);
     }
+  }
+
+  /** Re-apply the correct postal/zip code validator for every address in the form based on the
+   *  restored country value. This is needed after loading a draft because patchValue with
+   *  emitEvent:false does not trigger the country-change handlers that normally update validators. */
+  private reapplyPostalCodeValidators(): void {
+    const addressHelper = new AddressHelper();
+
+    const simpleAddressPaths = [
+      'personalInformation.primaryAddress',
+      'personalInformation.alternateAddress',
+      'victimInformation.primaryAddress',
+      'representativeInformation.representativeAddress',
+      'crimeInformation.racafInformation.lawyerAddress',
+      'medicalInformation.familyDoctorAddress'
+    ];
+
+    for (const path of simpleAddressPaths) {
+      addressHelper.updatePostalCodeValidatorByCountry(this.form.get(path) as UntypedFormGroup);
+    }
+
+    const treatmentsArray = this.form.get('medicalInformation.otherTreatments') as UntypedFormArray;
+    treatmentsArray?.controls.forEach((ctrl) =>
+      addressHelper.updatePostalCodeValidatorByCountry(ctrl.get('providerAddress') as UntypedFormGroup)
+    );
+
+    const authorizedPersonsArray = this.form.get('authorizationInformation.authorizedPerson') as UntypedFormArray;
+    authorizedPersonsArray?.controls.forEach((ctrl) =>
+      addressHelper.updatePostalCodeValidatorByCountry(ctrl.get('authorizedPersonAgencyAddress') as UntypedFormGroup)
+    );
   }
 
   private buildApplicationForm(): UntypedFormGroup {


### PR DESCRIPTION
…application forms

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

:information_source: [**Jira Ticket Number here**](Jira web address here)  

This pull request improves the way postal/zip code validators are reapplied to address fields after loading draft data in the IFM, Victim, and Witness application forms. It introduces a new helper method to ensure that country-specific postal code validation is correctly restored, even when form data is patched without triggering value change events. The changes also add a utility for debugging invalid form controls in the victim application.

**Address validation improvements:**

* Added a new `updatePostalCodeValidatorByCountry` method to `AddressHelper`, which reapplies the appropriate validator to an address form group based on its current country value, preserving any required constraints. This ensures that postal/zip code validation is accurate after restoring draft data.
* Updated `IfmApplicationComponent`, `VictimApplicationComponent`, and `WitnessApplicationComponent` to call a new `reapplyPostalCodeValidators` method after patching form data. This method iterates through all relevant address fields in the form and reapplies country-specific postal/zip code validators using the new helper. [[1]](diffhunk://#diff-7386393d6ab2419b8fd712b5339bade34f775c60047b166b71fa4a47c4a518a2R483-R486) [[2]](diffhunk://#diff-7386393d6ab2419b8fd712b5339bade34f775c60047b166b71fa4a47c4a518a2R508-R537) [[3]](diffhunk://#diff-1cf000bb3a8bc95e8768d91c32ef6531bc492d5ae8ae0edf45d889a63571fd10R701-R704) [[4]](diffhunk://#diff-1cf000bb3a8bc95e8768d91c32ef6531bc492d5ae8ae0edf45d889a63571fd10R727-R760) [[5]](diffhunk://#diff-0dfa6eaaaa89e5e9d4ab551979271cd5c8f73c57881848a87d88f43733baebe1R443-R446) [[6]](diffhunk://#diff-0dfa6eaaaa89e5e9d4ab551979271cd5c8f73c57881848a87d88f43733baebe1R468-R497)

**Code organization and imports:**

* Added missing imports for `AddressHelper` in all three application components to support the new validation logic. [[1]](diffhunk://#diff-7386393d6ab2419b8fd712b5339bade34f775c60047b166b71fa4a47c4a518a2R31) [[2]](diffhunk://#diff-1cf000bb3a8bc95e8768d91c32ef6531bc492d5ae8ae0edf45d889a63571fd10R30) [[3]](diffhunk://#diff-0dfa6eaaaa89e5e9d4ab551979271cd5c8f73c57881848a87d88f43733baebe1R30)
* Fixed the import order of `POSTAL_CODE` and `ZIP_CODE` in `address.helper.ts` for consistency.

**Developer experience:**

* Added a utility function in `VictimApplicationComponent` to recursively log invalid form controls and their errors, aiding in debugging form validation issues.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
